### PR TITLE
Allow constexpr on newer revisions of __cpp_constexpr.

### DIFF
--- a/ddspp.h
+++ b/ddspp.h
@@ -6,7 +6,7 @@
 // https://learn.microsoft.com/en-us/windows/win32/direct3ddds/dds-header-dxt10
 // https://learn.microsoft.com/en-us/windows/win32/direct3ddds/dds-pixelformat
 
-#if (__cpp_constexpr == 201304) || (_MSC_VER > 1900)
+#if (__cpp_constexpr >= 201304) || (_MSC_VER > 1900)
 #define ddspp_constexpr constexpr
 #else
 #define ddspp_constexpr const


### PR DESCRIPTION
It seems the macro disallows the use of constexpr on any newer revisions of the built-in macro.

I'm not sure if this is intentional, but it does bring up some warnings (and RT64 treats them as errors in CI) to use const in return types instead.

This change fixes the problem on my end.